### PR TITLE
fix(azure): provider auth

### DIFF
--- a/azure/main.tf
+++ b/azure/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 2.29.0"
+  version = "~> 2.92.0"
   features {}
   #skip_provider_registration = true
 }


### PR DESCRIPTION
azurerm provider needs to be updated due to a breaking change in auth causing this error:
```
Error: Error building AzureRM Client: Error populating Client ID from the Azure CLI: No Authorization Tokens were found - please re-authenticate using `az login`.

  on main.tf line 1, in provider "azurerm":
   1: provider "azurerm" {
```
see: https://stackoverflow.com/a/70736802