### PR TITLE
Use Standard_DS11_v2 node type on Azure

### DIFF
--- a/azure/main.tf
+++ b/azure/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_kubernetes_cluster" "placeos" {
     default_node_pool {
         name            = "agentpool"
         node_count      = 3
-        vm_size         = "Standard_D2_v3"
+        vm_size         = "Standard_DS11_v2"
     }
 
     service_principal {


### PR DESCRIPTION
Standard_D2_v3 has a volume per node limit of 4 which is not enough to scale all services with 3 nodes The memory on D2_v3 (and v2) is also below the combined requests of third party charts & requirements for placeos services when scaled